### PR TITLE
Pull Request: DataMade Code Challenge Submission

### DIFF
--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -87,4 +87,3 @@ document.getElementById("addressform").addEventListener("submit", function (e) {
     displayError("Address field is empty, cannot parse");
   }
 });
-

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -3,9 +3,7 @@
    but wasn't able to fix, and kept function as is */
 async function getAndDisplayAddressData(inputString) {
   const url = "api/parse/?input_string=" + inputString;
-  const response = await fetch(url, {
-    method: "GET",
-  })
+  const response = await fetch(url)
     .then((response) => response.json())
     .then((data) => {
       if (data.error) {
@@ -38,7 +36,7 @@ function displayError(errorMessage) {
 function displayResults(data) {
   // reveal the results table
   document.getElementById("address-results").style.display = "block";
-  console.log(data);
+
   // populate the address type
   document.getElementById("parse-type").innerHTML = data.address_type;
 
@@ -48,7 +46,7 @@ function displayResults(data) {
 
   // populate the tbody
   for (let [part, tag] of Object.entries(data.address_components)) {
-    console.log(part, tag);
+
     let row = document.createElement("tr");
     row.innerHTML = [`<td>${part}</td>`, `<td>${tag}</td>`].join("");
     tableBody.append(row);

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -44,12 +44,19 @@ function displayResults(data) {
   const tableBody = document.querySelector("#address-results table tbody");
   tableBody.innerHTML = "";
 
+  // get the reference to the table for populating
+  let tableRef = document.querySelector(".table");
+
   // populate the tbody
   for (let [part, tag] of Object.entries(data.address_components)) {
+    let newRow = tableRef.insertRow(-1);
 
-    let row = document.createElement("tr");
-    row.innerHTML = [`<td>${part}</td>`, `<td>${tag}</td>`].join("");
-    tableBody.append(row);
+    // Insert two new cells for the part and tag, with text content
+    let partCell = newRow.insertCell();
+    partCell.textContent = `${part}`;
+
+    let tagCell = newRow.insertCell();
+    tagCell.textContent = `${tag}`;
   }
 }
 

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,2 +1,91 @@
-/* Challenge: connect the form to the API and render results
-   in the #address-results div. */
+/* I got a lint error for this async function
+   "Unexpected token function"
+   but wasn't able to fix, and kept function as is */
+async function getAndDisplayAddressData(inputString) {
+  const url = "api/parse/?input_string=" + inputString;
+  const response = await fetch(url, {
+    method: "GET",
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      if (data.error) {
+        console.error(data.error);
+        displayError(data.error);
+      } else {
+        displayResults(data);
+      }
+    });
+}
+
+// display error returned from the API request in the error div
+function displayError(errorMessage) {
+  // this pattern is from getbootstrap.com/docs/5.2/components/alerts/#triggers
+  const alertPlaceholder = document.getElementById("alert-placeholder");
+
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = [
+    `<div class="alert alert-danger alert-dismissible" role="alert">`,
+    `   <div>${errorMessage}</div>`,
+    '   <button type="button" class="close" data-dismiss="alert" aria-label="Close">',
+    '     <span aria-hidden="true">&times;</span>',
+    "   </button>",
+    "</div>",
+  ].join("");
+
+  alertPlaceholder.append(wrapper);
+}
+
+function displayResults(data) {
+  // reveal the results table
+  document.getElementById("address-results").style.display = "block";
+  console.log(data);
+  // populate the address type
+  document.getElementById("parse-type").innerHTML = data.address_type;
+
+  //clear the tbody
+  const tableBody = document.querySelector("#address-results table tbody");
+  tableBody.innerHTML = "";
+
+  // populate the tbody
+  for (let [part, tag] of Object.entries(data.address_components)) {
+    console.log(part, tag);
+    let row = document.createElement("tr");
+    row.innerHTML = [`<td>${part}</td>`, `<td>${tag}</td>`].join("");
+    tableBody.append(row);
+  }
+}
+
+// get the address from the form
+function getAddressFromForm(submitEvent) {
+  // I was debating whether to use document.getElementById("address").value;
+  // but I think FormData accomodates a situation where more fields might
+  // be gathered in the future, or in case the id of element changes
+  const formData = new FormData(submitEvent.target);
+  const formProps = Object.fromEntries(formData);
+  return formProps.address;
+}
+
+function resetUI() {
+  // hide table in case it is there from previous request
+  document.getElementById("address-results").style.display = "none";
+
+  // hide error in case it's there
+  if (document.querySelector(".alert")) {
+    $(".alert-danger").alert("close");
+  }
+}
+
+// I'm going to override the default submit action for the 'Parse!' button
+document.getElementById("addressform").addEventListener("submit", function (e) {
+  e.preventDefault();
+  resetUI();
+
+  addressString = getAddressFromForm(e);
+
+  // Check for empty address
+  if (addressString) {
+    getAndDisplayAddressData(addressString);
+  } else {
+    displayError("Address field is empty, cannot parse");
+  }
+});

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -4,7 +4,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer
 # I didn't end up using ParseError
-# from rest_framework.exceptions import ParsaeError
+# from rest_framework.exceptions import ParseError
 
 
 class Home(TemplateView):

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -3,7 +3,8 @@ from django.views.generic import TemplateView
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer
-from rest_framework.exceptions import ParseError
+# I didn't end up using ParseError
+# from rest_framework.exceptions import ParsaeError
 
 
 class Home(TemplateView):
@@ -14,9 +15,25 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
-        return Response({})
+        # I'm passing in the input string as a request parameter
+        input_string = request.query_params.get("input_string")
+
+        try:
+            address_components, address_type = self.parse(input_string)
+
+            return Response({
+                'input_string': input_string,
+                'address_components': address_components,
+                'address_type': address_type
+            })
+
+        except TypeError:
+            return Response({'error': 'an unknown error occurred'}, status=400)
+        except Exception as e:
+            # Got to handle strings that cannot be parsed and return the error!
+            return Response({'error': str(e.message.split('\n')[1].strip())}, status=400)
 
     def parse(self, address):
         # usaddress: https://github.com/datamade/usaddress
-
+        address_components, address_type = usaddress.tag(address)
         return address_components, address_type

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,12 +1,53 @@
+# I got a lint error that pytest is imported but never used...
+# keeping this import statement here for testing anyway
 import pytest
+from django.urls import reverse
+import json
 
 
 def test_api_parse_succeeds(client):
     # Send a request to the API and confirm that the
     # data comes back in the appropriate format.
+    address_string = '123 main st chicago il'
+    url = reverse('address-parse')
+    url += '?input_string=' + address_string
 
+    correct_format = {
+        "input_string": "123 main st chicago il",
+        "address_components":
+            {
+                "AddressNumber": "123",
+                "StreetName": "main",
+                "StreetNamePostType": "st",
+                "PlaceName": "chicago",
+                "StateName": "il"
+            },
+            "address_type": "Street Address"
+        }
+
+    response = client.get(url)
+    address_data = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert address_data == correct_format
 
 
 def test_api_parse_raises_error(client):
     # The address_string below will raise a RepeatedLabelError,
     # so ParseAddress.parse() should not be able to parse it.
+    address_string = '123 main st chicago il 123 main st'
+    url = reverse('address-parse')
+    url += '?input_string=' + address_string
+
+    # Check for repeated label error
+    # note: eslint doesn't like the long line below, but test will not register
+    # equal json structure if I split the string up into two lines
+    correct_error_returned = {
+        'error':
+        'ERROR: Unable to tag this string because more than one area of the string has the same label'
+    }
+
+    response = client.get(url)
+    response_data = json.loads(response.content)
+    assert response.status_code == 400
+    assert response_data == correct_error_returned


### PR DESCRIPTION
## Overview

This pull request contains my code for the DataMade challenge, which is described in the README of this repo. T
I completed the following steps:

Step 1
I used [usaddress](https://github.com/datamade/usaddress) to implement the AddressParse.parse() method. Return two pieces of data:
* address_components: The parsed address
* address_type: The type of address provided

Step 2
In parserator_web/views.py, I completed the AddressParse.get() method to return three pieces of data:

*input_string: The string that the user sent
*address_components: A dictionary of parsed components that comprise the address, in the format `{address_part: tag}` 
*address_type: A string representing type of the parsed address (returned by `AddressParse.parse()`)

Step 3 & 4
Filled in the index.js file with JavaScript code that uses the form to send data to the API endpoint fleshed out in Step 2.
I then displayed the results from the API endpoint in the hidden element `<div id="address-results">`

Step 5
Completed the two tests in the `test_views.py`file.


### Notes
To test out the functionality, visit localhost:8000 after running:
`docker-compose build`
and
`docker-compose up`

To run the unit tests:
`docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app`



